### PR TITLE
Crash when you change your nick

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -101,10 +101,10 @@ func (irc *Connection) pingLoop() {
 			//Ping every 15 minutes.
 			irc.SendRawf("PING %d", time.Now().UnixNano())
 			//Try to recapture nickname if it's not as configured.
-			// if irc.nick != irc.nickcurrent {
-			// 	irc.nickcurrent = irc.nick
-			// 	irc.SendRawf("NICK %s", irc.nick)
-			// }
+			if irc.nick != irc.nickcurrent {
+				irc.nickcurrent = irc.nick
+				irc.SendRawf("NICK %s", irc.nick)
+			}
 		case <-irc.endping:
 			irc.ticker.Stop()
 			irc.ticker2.Stop()


### PR DESCRIPTION
to reproduce :    

```
 irccon := irc.IRC("gotest", "gotest")
irccon.VerboseCallbackHandler = true
irccon.Connect("irc.freenode.net:6667")
irccon.AddCallback("001", func(e *irc.Event) { irccon.Join("#gotest") })

irccon.AddCallback("366", func(e *irc.Event) {
    irccon.Privmsg("#gotest", "hi\n")
    irccon.SendRaw("NICK crashmeplz")
})
irccon.Loop()
```
