### PR TITLE
Added configurable timeouts and overridable version string

### DIFF
--- a/irc_callback.go
+++ b/irc_callback.go
@@ -84,7 +84,7 @@ func (irc *Connection) setupCallbacks() {
 
 	//Version handler
 	irc.AddCallback("CTCP_VERSION", func(e *Event) {
-		irc.SendRawf("NOTICE %s :\x01VERSION %s\x01", e.Nick, VERSION)
+		irc.SendRawf("NOTICE %s :\x01VERSION %s\x01", e.Nick, irc.Version)
 	})
 
 	irc.AddCallback("CTCP_USERINFO", func(e *Event) {

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -17,8 +17,13 @@ type Connection struct {
 	Password  string
 	UseTLS    bool
 	TLSConfig *tls.Config
+	Version   string
+	Timeout   time.Duration
+	PingFreq  time.Duration
+	KeepAlive time.Duration
 
 	socket                             net.Conn
+	netsock                            net.Conn
 	pread, pwrite                      chan string
 	readerExit, writerExit, pingerExit chan bool
 	endping                            chan bool


### PR DESCRIPTION
This patch adds in the ability to override the default version string (if you want to identify you're connection's client version differently) and also add in the ability to configure the ping frequency, keep alive and connection timeouts (some servers need special treatment or dislike ping frequencies that are too often, etc plus now things wont get locked up waiting forever on a connection to be established).

These are just exported properties on the main connection struct, so you can set them up after instantiating, like so:

``` go

conn := irc.IRC("nick", "user")
conn.KeepAlive = 4 * time.Minute
conn.Timeout = 1 * time.Minute
conn.PingFreq = 15 * time.Minute
conn.Version = "my-version-string"

```

The only caveat currently with this is that PingFreq _must_ be set before connecting, since the tickers do not get reinitialised.

There is no protection from setting 0 timeouts or 0 ping frequencies beyond the default behaviours for those things (tickers will panic on a 0 time duration, timeouts will be disabled when set to 0, keepalives will happen every minute if set to 0, since it's a wait time, not a frequency).

The default timeout values match the previously hard-coded values, which are the same as the values in the example above. 
