### PR TITLE
Deal with shutdowns more safely

### DIFF
--- a/irc_struct.go
+++ b/irc_struct.go
@@ -26,7 +26,7 @@ type Connection struct {
 	netsock                            net.Conn
 	pread, pwrite                      chan string
 	readerExit, writerExit, pingerExit chan bool
-	endping                            chan bool
+	endping, endread, endwrite         chan bool
 
 	nick        string //The nickname we want.
 	nickcurrent string //The nickname we currently have.


### PR DESCRIPTION
I found that if I called Quit, sometimes the Disconnect would happen whilst a callback was in progress and a write end up being sent to the now closed channel, causing the app to panic.

This patch adds in two more channels to kill the read and write loops early so that the above scenario can't happen, which the disconnect now triggers before closing the channels.
