### PR TITLE
Make IRC logger public. No reason for disallowing overrides.

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -57,7 +57,7 @@ func (irc *Connection) readLoop() {
 					msg = msg[i+1 : len(msg)]
 
 				} else {
-					irc.log.Printf("Misformed msg from server: %#s\n", msg)
+					irc.Log.Printf("Misformed msg from server: %#s\n", msg)
 				}
 
 				if i, j := strings.Index(event.Source, "!"), strings.Index(event.Source, "@"); i > -1 && j > -1 {
@@ -101,7 +101,7 @@ func (irc *Connection) writeLoop() {
 			}
 
 			if irc.Debug {
-				irc.log.Printf("--> %s\n", b)
+				irc.Log.Printf("--> %s\n", b)
 			}
 
 			// Set a write deadline based on the time out
@@ -157,11 +157,11 @@ func (irc *Connection) Loop() {
 		if irc.stopped {
 			break
 		}
-		irc.log.Printf("Error: %s\n", err)
+		irc.Log.Printf("Error: %s\n", err)
 		irc.Disconnect()
 		for !irc.stopped {
 			if err = irc.Connect(irc.server); err != nil {
-				irc.log.Printf("Error: %s\n", err)
+				irc.Log.Printf("Error: %s\n", err)
 				time.Sleep(1 * time.Second)
 			} else {
 				break
@@ -256,7 +256,7 @@ func (irc *Connection) Connect(server string) error {
 	if err != nil {
 		return err
 	}
-	irc.log.Printf("Connected to %s (%s)\n", irc.server, irc.socket.RemoteAddr())
+	irc.Log.Printf("Connected to %s (%s)\n", irc.server, irc.socket.RemoteAddr())
 
 	irc.pread = make(chan string, 10)
 	irc.pwrite = make(chan string, 10)
@@ -278,7 +278,7 @@ func IRC(nick, user string) *Connection {
 	irc := &Connection{
 		nick:       nick,
 		user:       user,
-		log:        log.New(os.Stdout, "", log.LstdFlags),
+		Log:        log.New(os.Stdout, "", log.LstdFlags),
 		readerExit: make(chan bool),
 		writerExit: make(chan bool),
 		pingerExit: make(chan bool),

--- a/irc_callback.go
+++ b/irc_callback.go
@@ -26,10 +26,10 @@ func (irc *Connection) ReplaceCallback(eventcode string, i int, callback func(*E
 			event[i] = callback
 			return
 		}
-		irc.log.Printf("Event found, but no callback found at index %d. Use AddCallback\n", i)
+		irc.Log.Printf("Event found, but no callback found at index %d. Use AddCallback\n", i)
 		return
 	}
-	irc.log.Printf("Event not found. Use AddCallBack\n")
+	irc.Log.Printf("Event not found. Use AddCallBack\n")
 }
 
 func (irc *Connection) RunCallbacks(event *Event) {
@@ -64,7 +64,7 @@ func (irc *Connection) RunCallbacks(event *Event) {
 
 	if callbacks, ok := irc.events[event.Code]; ok {
 		if irc.VerboseCallbackHandler {
-			irc.log.Printf("%v (%v) >> %#v\n", event.Code, len(callbacks), event)
+			irc.Log.Printf("%v (%v) >> %#v\n", event.Code, len(callbacks), event)
 		}
 
 		for _, callback := range callbacks {
@@ -72,7 +72,7 @@ func (irc *Connection) RunCallbacks(event *Event) {
 		}
 
 	} else if irc.VerboseCallbackHandler {
-		irc.log.Printf("%v (0) >> %#v\n", event.Code, event)
+		irc.Log.Printf("%v (0) >> %#v\n", event.Code, event)
 	}
 }
 
@@ -121,7 +121,7 @@ func (irc *Connection) setupCallbacks() {
 		ns, _ := strconv.ParseInt(e.Message, 10, 64)
 		delta := time.Duration(time.Now().UnixNano() - ns)
 		if irc.Debug {
-			irc.log.Printf("Lag: %vs\n", delta)
+			irc.Log.Printf("Lag: %vs\n", delta)
 		}
 	})
 

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -38,7 +38,7 @@ type Connection struct {
 	lastMessage time.Time
 
 	VerboseCallbackHandler bool
-	log                    *log.Logger
+	Log                    *log.Logger
 
 	stopped bool
 }


### PR DESCRIPTION
I found having access to the logger was useful (as part of a project, I sometimes want everything to use one global logger, or like to have each subsystem using a different logging prefix to make debugging easier). This patch makes the logger exported publicly so it can be overridden if required.
