### PR TITLE
sanity checks IRC() and Connect()

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -3,9 +3,9 @@
 // license that can be found in the LICENSE file.
 
 /*
-This package provides an event based IRC client library. It allows to 
-register callbacks for the events you need to handle. Its features 
-include handling standard CTCP, reconnecting on errors and detecting 
+This package provides an event based IRC client library. It allows to
+register callbacks for the events you need to handle. Its features
+include handling standard CTCP, reconnecting on errors and detecting
 stones servers.
 Details of the IRC protocol can be found in the following RFCs:
 https://tools.ietf.org/html/rfc1459
@@ -34,7 +34,6 @@ import (
 const (
 	VERSION = "go-ircevent v2.1"
 )
-
 
 // Read data from a connection. To be used as a goroutine.
 func (irc *Connection) readLoop() {
@@ -102,7 +101,6 @@ func (irc *Connection) readLoop() {
 	irc.readerExit <- true
 }
 
-
 // Loop to write to a connection. To be used as a goroutine.
 func (irc *Connection) writeLoop() {
 	for {
@@ -140,7 +138,6 @@ func (irc *Connection) writeLoop() {
 	irc.writerExit <- true
 }
 
-
 // Pings the server if we have not received any messages for 5 minutes
 // to keep the connection alive. To be used as a goroutine.
 func (irc *Connection) pingLoop() {
@@ -170,7 +167,6 @@ func (irc *Connection) pingLoop() {
 	}
 }
 
-
 // Main loop to control the connection.
 func (irc *Connection) Loop() {
 	for !irc.stopped {
@@ -191,7 +187,6 @@ func (irc *Connection) Loop() {
 	}
 }
 
-
 // Quit the current connection and disconnect from the server
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.1.6
 func (irc *Connection) Quit() {
@@ -200,13 +195,11 @@ func (irc *Connection) Quit() {
 	irc.Disconnect()
 }
 
-
 // Use the connection to join a given channel.
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.2.1
 func (irc *Connection) Join(channel string) {
 	irc.pwrite <- fmt.Sprintf("JOIN %s\r\n", channel)
 }
-
 
 // Leave a given channel.
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.2.2
@@ -214,13 +207,11 @@ func (irc *Connection) Part(channel string) {
 	irc.pwrite <- fmt.Sprintf("PART %s\r\n", channel)
 }
 
-
 // Send a notification to a nickname. This is similar to Privmsg but must not receive replies.
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.4.2
 func (irc *Connection) Notice(target, message string) {
 	irc.pwrite <- fmt.Sprintf("NOTICE %s :%s\r\n", target, message)
 }
-
 
 // Send a formated notification to a nickname.
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.4.2
@@ -228,31 +219,26 @@ func (irc *Connection) Noticef(target, format string, a ...interface{}) {
 	irc.Notice(target, fmt.Sprintf(format, a...))
 }
 
-
 // Send (private) message to a target (channel or nickname).
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.4.1
 func (irc *Connection) Privmsg(target, message string) {
 	irc.pwrite <- fmt.Sprintf("PRIVMSG %s :%s\r\n", target, message)
 }
 
-
 // Send formated string to specified target (channel or nickname).
 func (irc *Connection) Privmsgf(target, format string, a ...interface{}) {
 	irc.Privmsg(target, fmt.Sprintf(format, a...))
 }
-
 
 // Send raw string.
 func (irc *Connection) SendRaw(message string) {
 	irc.pwrite <- message + "\r\n"
 }
 
-
 // Send raw formated string.
 func (irc *Connection) SendRawf(format string, a ...interface{}) {
 	irc.SendRaw(fmt.Sprintf(format, a...))
 }
-
 
 // Set (new) nickname.
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.1.2
@@ -261,12 +247,10 @@ func (irc *Connection) Nick(n string) {
 	irc.SendRawf("NICK %s", n)
 }
 
-
 // Determine nick currently used with the connection.
 func (irc *Connection) GetNick() string {
 	return irc.nickcurrent
 }
-
 
 // Query information about a particular nickname.
 // RFC 1459: https://tools.ietf.org/html/rfc1459#section-4.5.2
@@ -274,13 +258,11 @@ func (irc *Connection) Whois(nick string) {
 	irc.SendRawf("WHOIS %s", nick)
 }
 
-
 // Query information about a given nickname in the server.
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.5.1
 func (irc *Connection) Who(nick string) {
 	irc.SendRawf("WHO %s", nick)
 }
-
 
 // Set different modes for a target (channel or nickname).
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.2.3
@@ -293,8 +275,7 @@ func (irc *Connection) Mode(target string, modestring ...string) {
 	irc.SendRawf("MODE %s", target)
 }
 
-
-// A disconnect sends all buffered messages (if possible), 
+// A disconnect sends all buffered messages (if possible),
 // stops all goroutines and then closes the socket.
 func (irc *Connection) Disconnect() {
 	irc.endping <- true
@@ -315,12 +296,10 @@ func (irc *Connection) Disconnect() {
 	irc.Error <- errors.New("Disconnect Called")
 }
 
-
 // Reconnect to a server using the current connection.
 func (irc *Connection) Reconnect() error {
 	return irc.Connect(irc.server)
 }
-
 
 // Connect to a given server using the current connection configuration.
 // This function also takes care of identification if a password is provided.
@@ -330,38 +309,37 @@ func (irc *Connection) Connect(server string) error {
 	irc.stopped = false
 
 	// make sure everything is ready for connection
-	if 0 == len(irc.server) {
+	if len(irc.server) == 0 {
 		return errors.New("empty 'server'")
 	}
-	if 1 != strings.Count(irc.server, ":") {
+	if strings.Count(irc.server, ":") != 1 {
 		return errors.New("wrong number of ':' in address")
 	}
-	if 0 == strings.Index(irc.server, ":") {
+	if strings.Index(irc.server, ":") == 0 {
 		return errors.New("hostname is missing")
 	}
-	if (len(irc.server) - 1) == strings.Index(irc.server, ":") {
+	if strings.Index(irc.server, ":") == len(irc.server)-1 {
 		return errors.New("port missing")
 	}
 	// check for valid range
 	ports := strings.Split(irc.server, ":")[1]
 	port, err := strconv.Atoi(ports)
-	if nil != err {
+	if err != nil {
 		return errors.New("extracting port failed")
 	}
 	if !((port >= 0) && (port <= 65535)) {
 		return errors.New("port number outside valid range")
 	}
-	if nil == irc.Log {
+	if irc.Log == nil {
 		return errors.New("'Log' points to nil")
 	}
-	if 0 == len(irc.nick) {
+	if len(irc.nick) == 0 {
 		return errors.New("empty 'user'")
 	}
-	if 0 == len(irc.user) {
+	if len(irc.user) == 0 {
 		return errors.New("empty 'user'")
 	}
 
-//	var err error
 	if irc.UseTLS {
 		if irc.netsock, err = net.DialTimeout("tcp", irc.server, irc.Timeout); err == nil {
 			irc.socket = tls.Client(irc.netsock, irc.TLSConfig)
@@ -390,16 +368,15 @@ func (irc *Connection) Connect(server string) error {
 	return nil
 }
 
-
 // Create a connection with the (publicly visible) nickname and username.
-// The nickname is later used to address the user. Returns nil if nick 
+// The nickname is later used to address the user. Returns nil if nick
 // or user are empty.
 func IRC(nick, user string) *Connection {
 	// catch invalid values
-	if 0 == len(nick) {
+	if len(nick) == 0 {
 		return nil
 	}
-	if 0 == len(user) {
+	if len(user) == 0 {
 		return nil
 	}
 
@@ -421,4 +398,3 @@ func IRC(nick, user string) *Connection {
 	irc.setupCallbacks()
 	return irc
 }
-

--- a/irc_test.go
+++ b/irc_test.go
@@ -210,7 +210,7 @@ func TestClearCallback(t *testing.T) {
 func TestIRCemptyNick(t *testing.T) {
 	irccon := IRC("", "go-eventirc")
 	irccon = nil
-	if nil != irccon {
+	if irccon != nil {
 		t.Error("empty nick didn't result in error")
 		t.Fail()
 	}
@@ -218,7 +218,7 @@ func TestIRCemptyNick(t *testing.T) {
  
 func TestIRCemptyUser(t *testing.T) {
 	irccon := IRC("go-eventirc", "")
-	if nil != irccon {
+	if irccon != nil {
 		t.Error("empty user didn't result in error")
 	}
 }


### PR DESCRIPTION
I added some sanity checks to make the code more robust againt errors. IRC() can handle empty strings know (e.g. when autogenerating an instance) and Connect() only establishes a connection if the internal data is well formed. All changes come with tests.
