### PR TITLE
Fix for reconnect and connection errors

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -172,7 +172,6 @@ func (irc *Connection) Loop() {
 			break
 		}
 		irc.Log.Printf("Error, disconnected: %s\n", err)
-		//irc.Disconnect()
 		for !irc.stopped {
 			if err = irc.Reconnect(); err != nil {
 				irc.Log.Printf("Error while reconnecting: %s\n", err)


### PR DESCRIPTION
Hey there, 

if an IRC connection is closed by the server (e.g. kill, ping timeout), the bot will panic, because Disconnect() is called twice, from the ERROR callback as well as from Loop():

```
panic: runtime error: close of closed channel
```

Futhermore `irc.end` is still closed on the reconnect attempt. As a result, the go routines will quit themselves immediately.
