### PR TITLE
Use tls.DialWithDialer instead of tls.Client and remove irc.netsock

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -299,10 +299,6 @@ func (irc *Connection) Disconnect() {
 	irc.Wait()
 	irc.socket.Close()
 	irc.socket = nil
-	if irc.netsock != nil {
-		irc.netsock.Close()
-		irc.netsock = nil
-	}
 	irc.ErrorChan() <- ErrDisconnected
 }
 
@@ -352,9 +348,8 @@ func (irc *Connection) Connect(server string) error {
 	}
 
 	if irc.UseTLS {
-		if irc.netsock, err = net.DialTimeout("tcp", irc.server, irc.Timeout); err == nil {
-			irc.socket = tls.Client(irc.netsock, irc.TLSConfig)
-		}
+		dialer := &net.Dialer{Timeout: irc.Timeout}
+		irc.socket, err = tls.DialWithDialer(dialer, "tcp", irc.server, irc.TLSConfig)
 	} else {
 		irc.socket, err = net.DialTimeout("tcp", irc.server, irc.Timeout)
 	}

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -24,10 +24,9 @@ type Connection struct {
 	PingFreq  time.Duration
 	KeepAlive time.Duration
 
-	socket  net.Conn
-	netsock net.Conn
-	pwrite  chan string
-	end     chan struct{}
+	socket net.Conn
+	pwrite chan string
+	end    chan struct{}
 
 	nick        string //The nickname we want.
 	nickcurrent string //The nickname we currently have.


### PR DESCRIPTION
This change removes the need to store the separate netsock for TLS connections. Of more interest, the change facilitates the passing of the zero configuration for the TLS parameter when the IRC server you are connecting to has proper SSL configuration. This is explicitly disallowed when using tls.Client per http://golang.org/pkg/crypto/tls/#Client. 

tls.DialWithDialer requires requires Go >= 1.3, so if supporting older versions is a consideration this change should not be applied.
