### PR TITLE
Verbose logging for ReadLoop().

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -69,6 +69,10 @@ func (irc *Connection) readLoop() {
 				break
 			}
 
+			if irc.Debug {
+				irc.Log.Printf("<-- %s\n", strings.TrimSpace(msg))
+			}
+
 			irc.lastMessage = time.Now()
 			msg = msg[:len(msg)-2] //Remove \r\n
 			event := &Event{Raw: msg}
@@ -97,10 +101,6 @@ func (irc *Connection) readLoop() {
 			}
 
 			/* XXX: len(args) == 0: args should be empty */
-			if irc.VerboseReadLoop {
-				irc.Log.Println(event.Raw)
-			}
-
 			irc.RunCallbacks(event)
 		}
 	}
@@ -122,7 +122,7 @@ func (irc *Connection) writeLoop() {
 			}
 
 			if irc.Debug {
-				irc.Log.Printf("--> %s\n", b)
+				irc.Log.Printf("--> %s\n", strings.TrimSpace(b))
 			}
 
 			// Set a write deadline based on the time out

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -38,7 +38,6 @@ type Connection struct {
 	lastMessage time.Time
 
 	VerboseCallbackHandler bool
-	VerboseReadLoop bool
 	Log                    *log.Logger
 
 	stopped bool


### PR DESCRIPTION
When developing a small IRC bot using go-ircevent, I found it difficult to troubleshoot why I was not getting the expected responses from the server. I added this verbose logging option to help in such situations. It's a boolean member of the Connection struct. When set to true, ReadLoop() will print all raw responses from the server to the standard log.

I also included a small error message text fix in this pull. 

Cheers!
-Ant
