### PR TITLE
Fixed NICK callback updating currentnick

### DIFF
--- a/irc_callback.go
+++ b/irc_callback.go
@@ -205,7 +205,7 @@ func (irc *Connection) setupCallbacks() {
 	// NICK Define a nickname.
 	// Set irc.nickcurrent to the new nick actually used in this connection.
 	irc.AddCallback("NICK", func(e *Event) {
-		if e.Nick == irc.nick {
+		if e.Nick == irc.nickcurrent && e.Arguments[0] == irc.nick {
 			irc.nickcurrent = e.Message()
 		}
 	})


### PR DESCRIPTION
This PR fixes the NICK callback responsible for updating `currentnick`. 

`e.Nick` is the old nickname, and `e.Arguments[0]` is the new nick. In `Nick(n string)` we set `nick` to the new nick, so the new nick `nick` can never equal the old nickname `e.Nick`. This PR corrects this check.

Note: The test was covering this feature was failing and is still failing. It looks like there may be a race condition between setting currentnick in one callback and reading currentnick in the next callback. I verified this works independent of `go test`.