### PR TITLE
Fix commands to correspond parameter name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,9 +41,9 @@ Events for callbacks
 AddCallback Example
 -------------------
 	ircobj.AddCallback("PRIVMSG", func(event *irc.Event) {
-		//e.Message() contains the message
-		//e.Nick Contains the sender
-		//e.Arguments[0] Contains the channel
+		//event.Message() contains the message
+		//event.Nick Contains the sender
+		//event.Arguments[0] Contains the channel
 	});
 
 Commands


### PR DESCRIPTION
If you copy the code in the README and uncomment the code, you will receive error saying that the `e is undefined`.