### PR TITLE
fixing small bugs

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -401,14 +401,15 @@ func IRC(nick, user string) *Connection {
 	}
 
 	irc := &Connection{
-		nick:      nick,
-		user:      user,
-		Log:       log.New(os.Stdout, "", log.LstdFlags),
-		end:       make(chan struct{}),
-		Version:   VERSION,
-		KeepAlive: 4 * time.Minute,
-		Timeout:   1 * time.Minute,
-		PingFreq:  15 * time.Minute,
+		nick:        nick,
+		nickcurrent: nick,
+		user:        user,
+		Log:         log.New(os.Stdout, "", log.LstdFlags),
+		end:         make(chan struct{}),
+		Version:     VERSION,
+		KeepAlive:   4 * time.Minute,
+		Timeout:     1 * time.Minute,
+		PingFreq:    15 * time.Minute,
 	}
 	irc.setupCallbacks()
 	return irc

--- a/irc.go
+++ b/irc.go
@@ -326,7 +326,8 @@ func (irc *Connection) Reconnect() error {
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.1
 func (irc *Connection) Connect(server string) error {
 	irc.Server = server
-	irc.stopped = false
+	// mark Server as stopped since there can be an error during connect
+	irc.stopped = true
 
 	// make sure everything is ready for connection
 	if len(irc.Server) == 0 {
@@ -369,6 +370,8 @@ func (irc *Connection) Connect(server string) error {
 	if err != nil {
 		return err
 	}
+
+	irc.stopped = false
 	irc.Log.Printf("Connected to %s (%s)\n", irc.Server, irc.socket.RemoteAddr())
 
 	irc.pwrite = make(chan string, 10)


### PR DESCRIPTION
The first Commit makes sure the Connection stays disconnected in case of an Error during Connect (old Connect would mark the Connection alive, which made Connected() return true even when encountering an error during Connect).

The Seconds commit makes the Nick() routine return the set Nickname after initialising the connection. The old version would return empty string.

Those were two small bugs i found while working with the lib