### PR TITLE
Fix - wait for waitgroup to sync before reconnecting 

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -317,6 +317,9 @@ func (irc *Connection) Disconnect() {
 
 // Reconnect to a server using the current connection.
 func (irc *Connection) Reconnect() error {
+	close(irc.end)
+	irc.Wait() //make sure that wait group is cleared ensuring that all spawned goroutines have completed
+
 	irc.end = make(chan struct{})
 	return irc.Connect(irc.Server)
 }


### PR DESCRIPTION
This patch closes end channel and makes sure that all currently running background go routines have called ```WaitGroup.Done()```, so no more runaway go routines if it reconnects(should fix #52)