### PR TITLE
Add support for specifying a quit message.

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -209,7 +209,13 @@ func (irc *Connection) Loop() {
 // Quit the current connection and disconnect from the server
 // RFC 1459 details: https://tools.ietf.org/html/rfc1459#section-4.1.6
 func (irc *Connection) Quit() {
-	irc.SendRaw("QUIT")
+	quit := "QUIT"
+
+	if irc.QuitMessage != "" {
+		quit = fmt.Sprintf("QUIT :%s", irc.QuitMessage)
+	}
+
+	irc.SendRaw(quit)
 	irc.stopped = true
 }
 
@@ -463,6 +469,7 @@ func IRC(nick, user string) *Connection {
 		KeepAlive:   4 * time.Minute,
 		Timeout:     1 * time.Minute,
 		PingFreq:    15 * time.Minute,
+		QuitMessage: "",
 	}
 	irc.setupCallbacks()
 	return irc

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -35,6 +35,7 @@ type Connection struct {
 	registered  bool
 	events      map[string]map[string]func(*Event)
 
+	QuitMessage string
 	lastMessage time.Time
 
 	VerboseCallbackHandler bool


### PR DESCRIPTION
Hey,

I noticed that there was no support for specifying a quit message, so I thought I'd fork/PR. Users are not required to set `QuitMessage`, as it will act as it currently does (just sending the nickname as the quit message).

This PR still confirms to [RFC1459](https://tools.ietf.org/html/rfc1459#section-4.1.6) and uses the preferred message format.