### PR TITLE
Issue 75: IMPLEMENT NAMES sendraw and 353 and 366 callbacks

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -307,6 +307,16 @@ func (irc *Connection) GetNick() string {
 	return irc.nickcurrent
 }
 
+// Query information about all nicks on a specific channel
+// RFC 2812 details: https://tools.ietf.org/html/rfc2812#section-3.2.5
+// Callback for 353 and 366 is what reads the info trigered by this into two
+// gobal maps. NickChanMap which is a map of irc channnels to golang chan []string
+// channels, and a NickChanState which is a map of irc channels to []string of
+// the resulting nicks
+func (irc *Connection) GetNicksOnChan(channel string) {
+	irc.SendRawf(fmt.Sprintf("NAMES %s", channel))
+}
+
 // Query information about a particular nickname.
 // RFC 1459: https://tools.ietf.org/html/rfc1459#section-4.5.2
 func (irc *Connection) Whois(nick string) {

--- a/irc_callback.go
+++ b/irc_callback.go
@@ -1,10 +1,14 @@
 package irc
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 )
+
+var NickChanMap = map[string]chan []string{}
+var NickChanState = map[string][]string{}
 
 // Register a callback to a connection and event code. A callback is a function
 // which takes only an Event pointer as parameter. Valid event codes are all
@@ -218,4 +222,58 @@ func (irc *Connection) setupCallbacks() {
 	irc.AddCallback("001", func(e *Event) {
 		irc.nickcurrent = e.Arguments[0]
 	})
+
+	// 353: RPL_NAMEREPLY per RFC1459
+	// will typically receive this on channel joins and when NAMES is
+	// called via GetNicksOnCHan
+	irc.AddCallback("353", func(e *Event) {
+		// get chan
+		re := regexp.MustCompile(`#\S+\s`)
+		channelName := re.FindString(e.Raw)
+		// check if chan exists in map
+		_, ok := NickChanMap[channelName]
+
+		// if not make one
+		if ok != true {
+			ch := make(chan []string, 1000)
+			NickChanMap[channelName] = ch
+		}
+		// split the datat into a slice
+		data := strings.Split(e.Message(), " ")
+
+		// then send
+		NickChanMap[channelName] <- data
+	})
+
+	// 363: RPL_ENDOFNAMES per RFC1459
+	// will receive this so we know that no more 353s are coming
+	irc.AddCallback("366", func(e *Event) {
+		go func(e *Event) {
+			// get chan
+			re := regexp.MustCompile(`#\S+\s`)
+			channelName := re.FindString(e.Raw)
+			// if channel doesn't exist return
+			c, ok := NickChanMap[channelName]
+			if ok != true {
+				return
+			}
+			// Note, callback 353 is not in a goroutine on purpose
+			// to prevent chance of channel being closed
+			// prematurely
+			close(c) // there's probably a more elegant way to do this
+			// append list of names
+			var theList []string
+			for r := range c {
+				theList = append(theList, r...)
+			}
+			// reset the channel with a new one since we closed the other
+			// one
+			ch := make(chan []string, 1000)
+			NickChanMap[channelName] = ch
+			// add theList of nicks to a global state var
+			NickChanState[channelName] = theList
+
+		}(e)
+	})
+
 }


### PR DESCRIPTION
Here you go. 

1 new func, 2 new callbacks, and 2 global vars. 

There's likely a cleaner way to do the concurrency and the global vars, but you don't know how many 353 events you will have before a 366. Also, there may be use cases where someone is calling a ton of different irc channels and receiving 353 events from multiple channels (i.e. at initial connection to all channels). 
It's a little dirty, but it's working fantastically for my single-irc-channel bot at the moment. Might need some concurrency cleaning up with mutexes / better channels than my implementation in the future. 