### PR TITLE
Add SASL (PLAIN) support

### DIFF
--- a/irc_struct.go
+++ b/irc_struct.go
@@ -14,16 +14,20 @@ import (
 
 type Connection struct {
 	sync.WaitGroup
-	Debug     bool
-	Error     chan error
-	Password  string
-	UseTLS    bool
-	TLSConfig *tls.Config
-	Version   string
-	Timeout   time.Duration
-	PingFreq  time.Duration
-	KeepAlive time.Duration
-	Server    string
+	Debug        bool
+	Error        chan error
+	Password     string
+	UseTLS       bool
+	UseSASL      bool
+	SASLLogin    string
+	SASLPassword string
+	SASLMech     string
+	TLSConfig    *tls.Config
+	Version      string
+	Timeout      time.Duration
+	PingFreq     time.Duration
+	KeepAlive    time.Duration
+	Server       string
 
 	socket net.Conn
 	pwrite chan string

--- a/sasl.go
+++ b/sasl.go
@@ -1,0 +1,54 @@
+package irc
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type SASLResult struct {
+	Failed bool
+	Err    error
+}
+
+func (irc *Connection) setupSASLCallbacks(result chan<- *SASLResult) {
+	irc.AddCallback("CAP", func(e *Event) {
+		if len(e.Arguments) == 3 {
+			if e.Arguments[1] == "LS" {
+				if !strings.Contains(e.Arguments[2], "sasl") {
+					result <- &SASLResult{true, errors.New("no SASL capability " + e.Arguments[2])}
+				}
+			}
+			if e.Arguments[1] == "ACK" {
+				if irc.SASLMech != "PLAIN" {
+					result <- &SASLResult{true, errors.New("only PLAIN is supported")}
+				}
+				irc.SendRaw("AUTHENTICATE " + irc.SASLMech)
+			}
+		}
+	})
+	irc.AddCallback("AUTHENTICATE", func(e *Event) {
+		str := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s\x00%s\x00%s", irc.SASLLogin, irc.SASLLogin, irc.SASLPassword)))
+		irc.SendRaw("AUTHENTICATE " + str)
+	})
+	irc.AddCallback("901", func(e *Event) {
+		irc.SendRaw("CAP END")
+		irc.SendRaw("QUIT")
+		result <- &SASLResult{true, errors.New(e.Arguments[1])}
+	})
+	irc.AddCallback("902", func(e *Event) {
+		irc.SendRaw("CAP END")
+		irc.SendRaw("QUIT")
+		result <- &SASLResult{true, errors.New(e.Arguments[1])}
+	})
+	irc.AddCallback("903", func(e *Event) {
+		irc.SendRaw("CAP END")
+		result <- &SASLResult{false, nil}
+	})
+	irc.AddCallback("904", func(e *Event) {
+		irc.SendRaw("CAP END")
+		irc.SendRaw("QUIT")
+		result <- &SASLResult{true, errors.New(e.Arguments[1])}
+	})
+}

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -1,0 +1,40 @@
+package irc
+
+import (
+	"crypto/tls"
+	"os"
+	"testing"
+	"time"
+)
+
+// set SASLLogin and SASLPassword environment variables before testing
+func TestConnectionSASL(t *testing.T) {
+	SASLServer := "irc.freenode.net:7000"
+	SASLLogin := os.Getenv("SASLLogin")
+	SASLPassword := os.Getenv("SASLPassword")
+
+	if SASLLogin == "" {
+		t.SkipNow()
+	}
+	irccon := IRC("go-eventirc", "go-eventirc")
+	irccon.VerboseCallbackHandler = true
+	irccon.Debug = true
+	irccon.UseTLS = true
+	irccon.UseSASL = true
+	irccon.SASLLogin = SASLLogin
+	irccon.SASLPassword = SASLPassword
+	irccon.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	irccon.AddCallback("001", func(e *Event) { irccon.Join("#go-eventirc") })
+
+	irccon.AddCallback("366", func(e *Event) {
+		irccon.Privmsg("#go-eventirc", "Test Message SASL\n")
+		time.Sleep(2 * time.Second)
+		irccon.Quit()
+	})
+
+	err := irccon.Connect(SASLServer)
+	if err != nil {
+		t.Fatal("SASL failed")
+	}
+	irccon.Loop()
+}


### PR DESCRIPTION
Implements sasl support for the PLAIN mechanism.
(http://ircv3.net/specs/extensions/sasl-3.1.html)

Allows connecting to freenode from restricted hosts (like AWS)