### PR TITLE
README: fixed test file path, converted it to github-flavored file link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ Install
 
 Example
 -------
-See test/irc_test.go
+See [irc_test.go](irc_test.go)
 
 Events for callbacks
 --------------------


### PR DESCRIPTION
Just a small README change that updates the test file location and sets it as a link.