### PR TITLE
make other threads exit if there's an error in one

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -198,6 +198,7 @@ func (irc *Connection) Loop() {
 	errChan := irc.ErrorChan()
 	for !irc.isQuitting() {
 		err := <-errChan
+		close(irc.end)
 		irc.Wait()
 		for !irc.isQuitting() {
 			irc.Log.Printf("Error, disconnected: %s\n", err)


### PR DESCRIPTION
irc.Wait() currently blocks the whole problem if there's an error in one of the loops because other threads never exit. Closing irc.end ensures that other threads exit.