### PR TITLE
Move pwrite channel creation to IRC()

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -420,7 +420,6 @@ func (irc *Connection) Connect(server string) error {
 	irc.stopped = false
 	irc.Log.Printf("Connected to %s (%s)\n", irc.Server, irc.socket.RemoteAddr())
 
-	irc.pwrite = make(chan string, 10)
 	irc.Error = make(chan error, 2)
 	irc.Add(3)
 	go irc.readLoop()
@@ -477,6 +476,8 @@ func IRC(nick, user string) *Connection {
 		PingFreq:    15 * time.Minute,
 		SASLMech:    "PLAIN",
 		QuitMessage: "",
+		
+		pwrite: make(chan string, 10),
 	}
 	irc.setupCallbacks()
 	return irc


### PR DESCRIPTION
This is so you can send commands before any other command.

---

I need this so I can send the `WEBIRC` command, which needs to be sent before any other command.

A better solution may be to support webirc out of the box, by requiring the individual items. Refer to [this issue](https://github.com/qaisjp/go-discord-irc/issues/2) for more details.