### PR TITLE
Fix dataraces and possible application stuck

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -74,9 +74,9 @@ func (irc *Connection) readLoop() {
 				irc.Log.Printf("<-- %s\n", strings.TrimSpace(msg))
 			}
 
-			irc.Lock()
+			irc.lastMessageMutex.Lock()
 			irc.lastMessage = time.Now()
-			irc.Unlock()
+			irc.lastMessageMutex.Unlock()
 			event, err := parseToEvent(msg)
 			event.Connection = irc
 			if err == nil {
@@ -166,9 +166,11 @@ func (irc *Connection) pingLoop() {
 		select {
 		case <-ticker.C:
 			//Ping if we haven't received anything from the server within the keep alive period
+			irc.lastMessageMutex.Lock()
 			if time.Since(irc.lastMessage) >= irc.KeepAlive {
 				irc.SendRawf("PING %d", time.Now().UnixNano())
 			}
+			irc.lastMessageMutex.Unlock()
 		case <-ticker2.C:
 			//Ping at the ping frequency
 			irc.SendRawf("PING %d", time.Now().UnixNano())

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -39,6 +39,7 @@ type Connection struct {
 	user        string
 	registered  bool
 	events      map[string]map[int]func(*Event)
+	eventsMutex sync.Mutex
 
 	QuitMessage string
 	lastMessage time.Time

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -43,6 +43,7 @@ type Connection struct {
 
 	QuitMessage string
 	lastMessage time.Time
+	lastMessageMutex sync.Mutex
 
 	VerboseCallbackHandler bool
 	Log                    *log.Logger


### PR DESCRIPTION
This PR fixes dataraces that appears on pings and working with events. Right now Go's maps aren't goroutine-safe, so we should use mutexes not only while writing, but also while reading.

Also pings and events now using two separate mutexes to get rid of possible application stuck if something goes wrong, e.g., while pinging.