### PR TITLE
Add support for Handler timeouts via context

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -21,6 +21,7 @@ package irc
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -79,6 +80,10 @@ func (irc *Connection) readLoop() {
 			irc.lastMessageMutex.Unlock()
 			event, err := parseToEvent(msg)
 			event.Connection = irc
+			event.Ctx = context.Background()
+			if irc.CallbackTimeout != 0 {
+				event.Ctx, _ = context.WithTimeout(event.Ctx, irc.CallbackTimeout)
+			}
 			if err == nil {
 				/* XXX: len(args) == 0: args should be empty */
 				irc.RunCallbacks(event)

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -5,6 +5,7 @@
 package irc
 
 import (
+	"context"
 	"crypto/tls"
 	"log"
 	"net"
@@ -17,7 +18,7 @@ type Connection struct {
 	sync.WaitGroup
 	Debug            bool
 	Error            chan error
-  WebIRC           string
+	WebIRC           string
 	Password         string
 	UseTLS           bool
 	UseSASL          bool
@@ -29,6 +30,7 @@ type Connection struct {
 	TLSConfig        *tls.Config
 	Version          string
 	Timeout          time.Duration
+	CallbackTimeout  time.Duration
 	PingFreq         time.Duration
 	KeepAlive        time.Duration
 	Server           string
@@ -69,6 +71,7 @@ type Event struct {
 	Arguments  []string
 	Tags       map[string]string
 	Connection *Connection
+	Ctx        context.Context
 }
 
 // Retrieve the last message from Event arguments.


### PR DESCRIPTION
Hi!
The idea here is to embed a context in to the Event and use it for canceling handlers that have hung or taken longer than you expected. I have left the default to no timeout to prevent surprises. 

If the timeout is exceeded it will let you know how long each previous callback took as well as the time that was spent executing the current one.

```
2018/05/11 19:18:14 TIMEOUT: 10s timeout expired while executing main.Sleeper, abandoning remaining callbacks
2018/05/11 19:18:14 Callback main.Sleeper took 4.000941132s
2018/05/11 19:18:14 Callback main.Sleeper took 4.001656901s
2018/05/11 19:18:14 Callback main.Sleeper ran for 2.000245256s prior to timeout
2018/05/11 19:18:14 Callback main.Sleeper did not run
2018/05/11 19:18:14 Callback main.Sleeper did not run
2018/05/11 19:18:14 Callback main.Sleeper did not run
```

I have gone back and forth on whether to consider this an error and to exit. This could introduce the ability to leak goroutines, although having the context should help with that (i.e. you can pass the ctx to a SQL request). Alternatively I could wait for something like timeout / 2 for the goroutine to exit cleanly, and bail if it does not. Any ideas are welcome. 