### PR TITLE
Run all callbacks in parallel

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -21,6 +21,7 @@ package irc
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -79,6 +80,10 @@ func (irc *Connection) readLoop() {
 			irc.lastMessageMutex.Unlock()
 			event, err := parseToEvent(msg)
 			event.Connection = irc
+			event.Ctx = context.Background()
+			if irc.CallbackTimeout != 0 {
+				event.Ctx, _ = context.WithTimeout(event.Ctx, irc.CallbackTimeout)
+			}
 			if err == nil {
 				/* XXX: len(args) == 0: args should be empty */
 				irc.RunCallbacks(event)

--- a/irc_parse_test.go
+++ b/irc_parse_test.go
@@ -1,7 +1,6 @@
 package irc
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -37,7 +36,7 @@ func TestParseTags(t *testing.T) {
 		t.Fatal("Parse PRIVMSG with tags failed")
 	}
 	checkResult(t, event)
-	fmt.Printf("%s", event.Tags)
+	t.Logf("%s", event.Tags)
 	if _, ok := event.Tags["tag"]; !ok {
 		t.Fatal("Parsing value-less tag failed")
 	}

--- a/irc_sasl_test.go
+++ b/irc_sasl_test.go
@@ -16,6 +16,9 @@ func TestConnectionSASL(t *testing.T) {
 	if SASLLogin == "" {
 		t.Skip("Define SASLLogin and SASLPasword environment varables to test SASL")
 	}
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	irccon := IRC("go-eventirc", "go-eventirc")
 	irccon.VerboseCallbackHandler = true
 	irccon.Debug = true

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -5,6 +5,7 @@
 package irc
 
 import (
+	"context"
 	"crypto/tls"
 	"log"
 	"net"
@@ -17,7 +18,7 @@ type Connection struct {
 	sync.WaitGroup
 	Debug            bool
 	Error            chan error
-  WebIRC           string
+	WebIRC           string
 	Password         string
 	UseTLS           bool
 	UseSASL          bool
@@ -29,6 +30,7 @@ type Connection struct {
 	TLSConfig        *tls.Config
 	Version          string
 	Timeout          time.Duration
+	CallbackTimeout  time.Duration
 	PingFreq         time.Duration
 	KeepAlive        time.Duration
 	Server           string
@@ -69,6 +71,7 @@ type Event struct {
 	Arguments  []string
 	Tags       map[string]string
 	Connection *Connection
+	Ctx        context.Context
 }
 
 // Retrieve the last message from Event arguments.


### PR DESCRIPTION
This builds on my previous support for using contexts + a timeout but runs all the callbacks in parallel. This makes the timeout a little easier to understand since a long-running handler doesn't mean that later handlers will time out. Ideally should should be a no-op since the handlers were already run in a random order. 