### PR TITLE
Fix SASL where additional caps are requested

### DIFF
--- a/irc_sasl.go
+++ b/irc_sasl.go
@@ -20,7 +20,7 @@ func (irc *Connection) setupSASLCallbacks(result chan<- *SASLResult) {
 					result <- &SASLResult{true, errors.New("no SASL capability " + e.Arguments[2])}
 				}
 			}
-			if e.Arguments[1] == "ACK" {
+			if e.Arguments[1] == "ACK" && e.Arguments[2] == "sasl" {
 				if irc.SASLMech != "PLAIN" {
 					result <- &SASLResult{true, errors.New("only PLAIN is supported")}
 				}


### PR DESCRIPTION
Where additional caps were requested using `RequestCaps`, SASL would
send an `AUTHENTICATE` command for each one which servers don't like.
Check that we're responding to the correct `CAP ACK`.