### PR TITLE
Don’t send NICK and USER commands while negotiating caps

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -568,13 +568,6 @@ func (irc *Connection) negotiateCaps() error {
 	}
 	irc.pwrite <- fmt.Sprintf("CAP END\r\n")
 
-	realname := irc.user
-	if irc.RealName != "" {
-		realname = irc.RealName
-	}
-
-	irc.pwrite <- fmt.Sprintf("NICK %s\r\n", irc.nick)
-	irc.pwrite <- fmt.Sprintf("USER %s 0.0.0.0 0.0.0.0 :%s\r\n", irc.user, realname)
 	return nil
 }
 


### PR DESCRIPTION
These lines seem to have been copy pasted from Connect() accidentally, causing the library to send duplicate NICK and USER commands when using RequestCaps.

On Twitch.tv's chat servers this causes `NOTICE * :NICK already set` and an immediate disconnect from their end