### PR TITLE
Add IPv6 address support

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -428,7 +428,7 @@ func (irc *Connection) Connect(server string) error {
 	if len(irc.Server) == 0 {
 		return errors.New("empty 'server'")
 	}
-	if strings.Count(irc.Server, ":") != 1 {
+	if !strings.HasPrefix("[", irc.Server) && strings.Count(irc.Server, ":") != 1 {
 		return errors.New("wrong number of ':' in address")
 	}
 	if strings.Index(irc.Server, ":") == 0 {
@@ -438,7 +438,8 @@ func (irc *Connection) Connect(server string) error {
 		return errors.New("port missing")
 	}
 	// check for valid range
-	ports := strings.Split(irc.Server, ":")[1]
+	substrings := strings.Split(irc.Server, ":")
+	ports := substrings[len(substrings) - 1]
 	port, err := strconv.Atoi(ports)
 	if err != nil {
 		return errors.New("extracting port failed")

--- a/irc.go
+++ b/irc.go
@@ -428,18 +428,16 @@ func (irc *Connection) Connect(server string) error {
 	if len(irc.Server) == 0 {
 		return errors.New("empty 'server'")
 	}
-	if !strings.HasPrefix("[", irc.Server) && strings.Count(irc.Server, ":") != 1 {
-		return errors.New("wrong number of ':' in address")
-	}
 	if strings.Index(irc.Server, ":") == 0 {
 		return errors.New("hostname is missing")
 	}
 	if strings.Index(irc.Server, ":") == len(irc.Server)-1 {
 		return errors.New("port missing")
 	}
-	// check for valid range
-	substrings := strings.Split(irc.Server, ":")
-	ports := substrings[len(substrings) - 1]
+	_, ports, err := net.SplitHostPort(irc.Server)
+	if err != nil {
+		return errors.New("wrong address string")
+	}
 	port, err := strconv.Atoi(ports)
 	if err != nil {
 		return errors.New("extracting port failed")


### PR DESCRIPTION
I'm writing a bot for our network, which is only available by IPv6 address. The address should look like "[::1]:6667".

Not sure if everything here is good, but the bot works and quick tests pass.