### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -381,7 +381,7 @@ func (irc *Connection) ErrorChan() chan error {
 	return irc.Error
 }
 
-// Returns true if the connection is connected to an IRC server.
+// Connected returns true if the connection is connected to an IRC server.
 func (irc *Connection) Connected() bool {
 	return !irc.stopped
 }

--- a/irc_callback.go
+++ b/irc_callback.go
@@ -31,7 +31,7 @@ func (irc *Connection) AddCallback(eventcode string, callback func(*Event)) int 
 	return id
 }
 
-// Remove callback i (ID) from the given event code. This functions returns
+// RemoveCallback removes callback i (ID) from the given event code. This functions returns
 // true upon success, false if any error occurs.
 func (irc *Connection) RemoveCallback(eventcode string, i int) bool {
 	eventcode = strings.ToUpper(eventcode)
@@ -54,7 +54,7 @@ func (irc *Connection) RemoveCallback(eventcode string, i int) bool {
 	return false
 }
 
-// Remove all callbacks from a given event code. It returns true
+// ClearCallback removes all callbacks from a given event code. It returns true
 // if given event code is found and cleared.
 func (irc *Connection) ClearCallback(eventcode string) bool {
 	eventcode = strings.ToUpper(eventcode)
@@ -72,7 +72,7 @@ func (irc *Connection) ClearCallback(eventcode string) bool {
 	return false
 }
 
-// Replace callback i (ID) associated with a given event code with a new callback function.
+// ReplaceCallback replaces callback i (ID) associated with a given event code with a new callback function.
 func (irc *Connection) ReplaceCallback(eventcode string, i int, callback func(*Event)) {
 	eventcode = strings.ToUpper(eventcode)
 
@@ -89,7 +89,7 @@ func (irc *Connection) ReplaceCallback(eventcode string, i int, callback func(*E
 	irc.Log.Printf("Event not found. Use AddCallBack\n")
 }
 
-// Execute all callbacks associated with a given event.
+// RunCallbacks executes all callbacks associated with a given event.
 func (irc *Connection) RunCallbacks(event *Event) {
 	msg := event.Message()
 	if event.Code == "PRIVMSG" && len(msg) > 2 && msg[0] == '\x01' {

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -75,7 +75,7 @@ type Event struct {
 	Ctx        context.Context
 }
 
-// Retrieve the last message from Event arguments.
+// Message retrieves the last message from Event arguments.
 // This function leaves the arguments untouched and
 // returns an empty string if there are none.
 func (e *Event) Message() string {
@@ -89,7 +89,7 @@ func (e *Event) Message() string {
 // Regex of IRC formatting.
 var ircFormat = regexp.MustCompile(`[\x02\x1F\x0F\x16\x1D\x1E]|\x03(\d\d?(,\d\d?)?)?`)
 
-// Retrieve the last message from Event arguments, but without IRC formatting (color.
+// MessageWithoutFormat retrieves the last message from Event arguments, but without IRC formatting (color.
 // This function leaves the arguments untouched and
 // returns an empty string if there are none.
 func (e *Event) MessageWithoutFormat() string {


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!