### PR TITLE
Support SASL EXTERNAL and proxies for TLS connections

### DIFF
--- a/examples/simple-tor.go/simple-tor.go
+++ b/examples/simple-tor.go/simple-tor.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/thoj/go-ircevent"
+	"crypto/tls"
+	"log"
+	"os"
+)
+
+const addr = "libera75jm6of4wxpxt4aynol3xjmbtxgfyjpu34ss4d7r7q2v5zrpyd.onion:6697"
+
+// This demos connecting to Libera.Chat over TOR using SASL EXTERNAL and a TLS
+// client cert. It assumes a TOR SOCKS service is running on localhost:9050
+// and requires an existing account with a fingerprint already registered. See
+// https://libera.chat/guides/connect#accessing-liberachat-via-tor for details.
+//
+// Pass the full path to your cert and key on the command line like so:
+// $ go run simple-tor.go my-nick my-cert.pem my-key.pem
+
+func main() {
+	os.Setenv("ALL_PROXY", "socks5h://localhost:9050")
+	nick, certFile := os.Args[1], os.Args[2]
+	keyFile := certFile
+	if len(os.Args) == 4 {
+		keyFile = os.Args[3]
+	}
+	clientCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ircnick1 := nick
+	irccon := irc.IRC(ircnick1, nick)
+	irccon.VerboseCallbackHandler = true
+	irccon.UseSASL = true
+	irccon.SASLMech = "EXTERNAL"
+	irccon.Debug = true
+	irccon.UseTLS = true
+	irccon.TLSConfig = &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates: []tls.Certificate{clientCert},
+	}
+	irccon.AddCallback("001", func(e *irc.Event) {})
+	irccon.AddCallback("376", func(e *irc.Event) {
+		log.Println("Quitting")
+		irccon.Quit()
+	})
+	err = irccon.Connect(addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	irccon.Loop()
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/thoj/go-ircevent
 
 go 1.12
 
-require golang.org/x/text v0.3.2
+require (
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
+	golang.org/x/text v0.3.6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,10 @@
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/irc_sasl_test.go
+++ b/irc_sasl_test.go
@@ -41,3 +41,49 @@ func TestConnectionSASL(t *testing.T) {
 	}
 	irccon.Loop()
 }
+
+
+// 1. Register fingerprint with IRC network
+// 2. Add SASLKeyPem="-----BEGIN PRIVATE KEY-----..."
+//    and SASLCertPem="-----BEGIN CERTIFICATE-----..."
+//    to CI environment as masked variables
+func TestConnectionSASLExternal(t *testing.T) {
+	SASLServer := "irc.freenode.net:7000"
+	keyPem := os.Getenv("SASLKeyPem")
+	certPem := os.Getenv("SASLCertPem")
+
+	if certPem == "" || keyPem == "" {
+		t.Skip("Env vars SASLKeyPem SASLCertPem not present, skipping")
+	}
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	cert, err := tls.X509KeyPair([]byte(certPem), []byte(keyPem))
+	if err != nil {
+		t.Fatalf("SASL EXTERNAL cert creation failed: %s", err)
+	}
+
+	irccon := IRC("go-eventirc", "go-eventirc")
+	irccon.VerboseCallbackHandler = true
+	irccon.Debug = true
+	irccon.UseTLS = true
+	irccon.UseSASL = true
+	irccon.SASLMech = "EXTERNAL"
+	irccon.TLSConfig = &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates: []tls.Certificate{cert},
+	}
+	irccon.AddCallback("001", func(e *Event) { irccon.Join("#go-eventirc") })
+
+	irccon.AddCallback("366", func(e *Event) {
+		irccon.Privmsg("#go-eventirc", "Test Message SASL EXTERNAL\n")
+		time.Sleep(2 * time.Second)
+		irccon.Quit()
+	})
+
+	err = irccon.Connect(SASLServer)
+	if err != nil {
+		t.Fatalf("SASL EXTERNAL failed: %s", err)
+	}
+	irccon.Loop()
+}


### PR DESCRIPTION
Hi, thanks for making this library.

These changes are pretty minimal but may not be useful enough to warrant inclusion. I can probably do better if it turns out folks are at all interested.

*Update*

I've changed things up slightly so the proxy settings affect non-TLS connections as well.

Most likely you know this, but in case there are new people around, it's sometimes convenient to use SSH as a SOCKS5 proxy service for trying things out locally. You can see the effects of both normal and TLS connections by running a simple server, like Oragono, on 6667 and 6697.

```console
$ docker run --rm \
  --publish 127.0.0.1:6667:6667 \
  --publish 127.0.0.1:6697:6697 \
  docker.io/oragono/oragono:v2.6.1
```

On Linux you'd then do something like the following:

1. If sshd isn't running, start it locally (you don't have to open any ports)
   and add your public key to `.ssh/authorized_keys`, perhaps temporarily
2. In a terminal, run `sudo tcpdump -i lo -nnX "port 1080"`
3. And in another terminal: `ssh -TND 1080 localhost`
4. Tweak the examples/tests to expect your Oragono instance
5. Export `ALL_PROXY=socks5h://localhost:1080`
6. Fire up a go-ircevent session

To also try the `EXTERNAL` stuff using a similar setup, first connect with a normal client using the same TLS client cert and nick and run `/msg NickServ REGISTER *`. Optionally, verify the fingerprint has indeed been added with `/msg NickServ CERT LIST`.

Note: this SASL business is basically orthogonal to the proxy stuff above, so I'd be happy to move it to a separate PR if that would help keep things sane. Thanks.

See also #136 and `examples/simple-tor.go` (related).